### PR TITLE
Fix Bug in Retag Command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/RetagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RetagCommand.java
@@ -67,7 +67,7 @@ public class RetagCommand extends Command {
 
         // Check if newTagName is in tag list
         List<Tag> newTagList = model.findFilteredTagList(new TagNameEqualsKeywordPredicate(newTagName));
-        if (!newTagList.isEmpty()) {
+        if (!newTagList.isEmpty() && !newTagName.equals(oldTagName)) {
             throw new CommandException(String.format(MESSAGE_DUPLICATE_TAG));
         }
 

--- a/src/test/java/seedu/address/logic/commands/RetagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RetagCommandTest.java
@@ -25,13 +25,18 @@ public class RetagCommandTest {
     }
 
     @Test
-    public void execute_duplicateNewTagName_throwsCommandException() {
-        TagName oldTag = new TagBuilder().build().getTagName();
-        TagName newTag = new TagBuilder().build().getTagName();
+    public void execute_duplicateNewTagName_retagSuccess() {
+        TagName oldTagName = new TagBuilder().build().getTagName();
+        TagName newTagName = new TagBuilder().build().getTagName();
 
-        RetagCommand retagCommand = new RetagCommand(oldTag, newTag);
+        Tag newTag = new TagBuilder().withTagName(newTagName.toString()).build();
 
-        assertThrows(CommandException.class, RetagCommand.MESSAGE_DUPLICATE_TAG, () -> retagCommand.execute(modelStub));
+        ModelStubWithTagAndTaglist expectedModelStub = new ModelStubWithTagAndTaglist(newTag);
+
+        RetagCommand retagCommand = new RetagCommand(oldTagName, newTagName);
+
+        assertCommandSuccess(retagCommand, modelStub,
+                String.format(retagCommand.MESSAGE_RETAG_TAG_SUCCESS, oldTagName, newTagName), expectedModelStub);
     }
 
     @Test


### PR DESCRIPTION
User now can retag with the same old and new tag without being prompt
error message of duplicated tag name

Also, modified the test cases to assert success instead of assert throws