### PR TITLE
Fix TagCommand using incorrect path when using relative path

### DIFF
--- a/src/main/java/seedu/address/logic/commands/TagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TagCommand.java
@@ -10,7 +10,6 @@ import java.nio.file.Paths;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.tag.FileAddress;
 import seedu.address.model.tag.Tag;
 
 /**

--- a/src/main/java/seedu/address/logic/commands/TagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TagCommand.java
@@ -48,7 +48,6 @@ public class TagCommand extends Command {
     private boolean filePresent(String address) {
         assert address != null;
         File file = new File(address);
-        System.out.println(file.getAbsolutePath());
         return file.exists();
     }
 

--- a/src/main/java/seedu/address/logic/commands/TagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TagCommand.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_LABEL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG_NAME;
 
 import java.io.File;
+import java.nio.file.Paths;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -44,9 +45,10 @@ public class TagCommand extends Command {
         toTag = tag;
     }
 
-    private boolean filePresent(FileAddress address) {
+    private boolean filePresent(String address) {
         assert address != null;
-        File file = new File(address.value);
+        File file = new File(address);
+        System.out.println(file.getAbsolutePath());
         return file.exists();
     }
 
@@ -66,12 +68,22 @@ public class TagCommand extends Command {
         }
 
         // Check if file is present
-        if (!filePresent(toTag.getFileAddress())) {
-            throw new CommandException(
-                    String.format(MESSAGE_FILE_NOT_FOUND, toTag.getFileAddress().value));
+        String path;
+        boolean isAbsolutePath = Paths.get(toTag.getFileAddress().value).isAbsolute();
+
+        if (isAbsolutePath) {
+            path = toTag.getFileAddress().value;
+        } else {
+            path = Paths.get(model.getCurrentPath().getAddress().value, toTag.getFileAddress().value)
+                    .normalize().toString();
         }
 
-        model.addTag(toTag.toAbsolute());
+        if (!filePresent(path)) {
+            throw new CommandException(
+                    String.format(MESSAGE_FILE_NOT_FOUND, path));
+        }
+
+        model.addTag(toTag.toAbsolute(isAbsolutePath, model.getCurrentPath().getAddress()));
         return new CommandResult(String.format(MESSAGE_SUCCESS, toTag));
     }
 

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -3,6 +3,7 @@ package seedu.address.model.tag;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.io.File;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
@@ -52,12 +53,19 @@ public class Tag {
      * @return The same tag but with absolute file address.
      * @throws IllegalArgumentException If file does not exist.
      */
-    public Tag toAbsolute() {
-        File file = new File(fileAddress.value);
+    public Tag toAbsolute(boolean isAbsolutePath, FileAddress currentPath) {
+        File file;
+
+        if (isAbsolutePath) {
+            file = new File(fileAddress.value);
+        } else {
+            file = new File(currentPath.value, fileAddress.value);
+        }
+
         if (!file.exists()) {
             throw new IllegalArgumentException("Tag address not valid!");
         }
-        FileAddress absAddress = new FileAddress(file.getAbsolutePath());
+        FileAddress absAddress = new FileAddress(Paths.get(file.getAbsolutePath()).normalize().toString());
 
         return new Tag(tagName, absAddress, labels);
     }

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -2,7 +2,9 @@ package seedu.address.logic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
-import static seedu.address.logic.commands.CommandTestUtil.*;
+import static seedu.address.logic.commands.CommandTestUtil.FILE_ADDRESS_DESC_CS2101;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_CS2101;
+import static seedu.address.logic.commands.CommandTestUtil.USER_DIRECTORY_ADDRESS;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalTags.CS2101;
 

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -2,8 +2,7 @@ package seedu.address.logic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
-import static seedu.address.logic.commands.CommandTestUtil.FILE_ADDRESS_DESC_CS2101;
-import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_CS2101;
+import static seedu.address.logic.commands.CommandTestUtil.*;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalTags.CS2101;
 
@@ -24,6 +23,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.tag.FileAddress;
 import seedu.address.model.tag.Tag;
 import seedu.address.storage.JsonAddressBookStorage;
 import seedu.address.storage.JsonUserPrefsStorage;
@@ -82,7 +82,7 @@ public class LogicManagerTest {
                 + FILE_ADDRESS_DESC_CS2101;
         Tag expectedTag = new TagBuilder(CS2101).build();
         ModelManager expectedModel = new ModelManager();
-        expectedModel.addTag(expectedTag.toAbsolute());
+        expectedModel.addTag(expectedTag.toAbsolute(false, new FileAddress(USER_DIRECTORY_ADDRESS)));
         String expectedMessage = LogicManager.FILE_OPS_ERROR_MESSAGE + DUMMY_IO_EXCEPTION;
         assertCommandFailure(tagCommand, CommandException.class, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -27,6 +27,7 @@ public class CommandTestUtil {
     public static final String VALID_TAG_NAME_CS2103 = "cs2103";
     public static final String VALID_TAG_NAME_CS2101 = "cs2101";
     public static final String INVALID_TAG_NAME = "&";
+    public static final String USER_DIRECTORY_ADDRESS = System.getProperty("user.dir");
     public static final String VALID_FILE_ADDRESS_CS2103 = "./src/test/java/seedu/address/testutil/cs2103.bat";
     public static final String VALID_FILE_ADDRESS_CS2101 = "./src/test/java/seedu/address/testutil/cs2101.bat";
     public static final String VALID_MAC_FILE_ADDRESS_CS2101 = "./src/test/java/seedu/address/testutil/cs2101.sh";

--- a/src/test/java/seedu/address/logic/commands/ModelStubWithTagAndTaglist.java
+++ b/src/test/java/seedu/address/logic/commands/ModelStubWithTagAndTaglist.java
@@ -5,13 +5,17 @@ import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import seedu.address.model.explorer.CurrentPath;
+import seedu.address.model.explorer.FileList;
 import seedu.address.model.tag.Tag;
 
 public class ModelStubWithTagAndTaglist extends ModelStub {
     private final List<Tag> tags;
+    private final CurrentPath currentPath;
 
     ModelStubWithTagAndTaglist() {
         tags = new ArrayList<>();
+        currentPath = new CurrentPath(System.getProperty("user.dir"), new FileList());
     }
 
     @Override
@@ -27,6 +31,11 @@ public class ModelStubWithTagAndTaglist extends ModelStub {
     @Override
     public boolean hasTag(Tag tag) {
         return tags.contains(tag);
+    }
+
+    @Override
+    public CurrentPath getCurrentPath() {
+        return this.currentPath;
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/TagCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/TagCommandIntegrationTest.java
@@ -1,5 +1,9 @@
 package seedu.address.logic.commands;
 
+import static seedu.address.logic.commands.CommandTestUtil.USER_DIRECTORY_ADDRESS;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.model.Model;
@@ -7,8 +11,6 @@ import seedu.address.model.ModelManager;
 import seedu.address.model.tag.FileAddress;
 import seedu.address.model.tag.Tag;
 import seedu.address.testutil.TagBuilder;
-
-import static seedu.address.logic.commands.CommandTestUtil.*;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code AddCommand}.

--- a/src/test/java/seedu/address/logic/commands/TagCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/TagCommandIntegrationTest.java
@@ -1,14 +1,14 @@
 package seedu.address.logic.commands;
 
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-
 import org.junit.jupiter.api.Test;
 
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
+import seedu.address.model.tag.FileAddress;
 import seedu.address.model.tag.Tag;
 import seedu.address.testutil.TagBuilder;
+
+import static seedu.address.logic.commands.CommandTestUtil.*;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code AddCommand}.
@@ -21,7 +21,7 @@ public class TagCommandIntegrationTest {
         Tag validTag = new TagBuilder().build();
 
         Model expectedModel = new ModelStubWithTagAndTaglist();
-        expectedModel.addTag(validTag.toAbsolute());
+        expectedModel.addTag(validTag.toAbsolute(false, new FileAddress(USER_DIRECTORY_ADDRESS)));
 
         assertCommandSuccess(new TagCommand(validTag), model,
                 String.format(TagCommand.MESSAGE_SUCCESS, validTag), expectedModel);
@@ -31,7 +31,7 @@ public class TagCommandIntegrationTest {
     public void execute_duplicateTag_throwsCommandException() {
         Model model = new ModelManager();
         Tag validTag = new TagBuilder().build();
-        model.addTag(validTag.toAbsolute());
+        model.addTag(validTag.toAbsolute(false, new FileAddress(USER_DIRECTORY_ADDRESS)));
         assertCommandFailure(new TagCommand(validTag), model, TagCommand.MESSAGE_DUPLICATE_TAG);
     }
 


### PR DESCRIPTION
Fix tagCommand using default directory path instead of current path if we use relative path in the Command.