### PR TITLE
Fix tagCommand and show/openCommand bug

### DIFF
--- a/src/main/java/seedu/address/logic/commands/TagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TagCommand.java
@@ -67,27 +67,28 @@ public class TagCommand extends Command {
 
         // Check if file is present
         String path;
-        String a = toTag.getFileAddress().value;
         boolean isAbsolutePath = Paths.get(toTag.getFileAddress().value).isAbsolute();
 
         path = toTag.getFileAddress().value;
-        Tag tag = toTag;
+
         if (!isAbsolutePath) {
             path = Paths.get(model.getCurrentPath().getAddress().value, toTag.getFileAddress().value)
                     .normalize().toString();
-            tag = toTag.toAbsolute(isAbsolutePath, model.getCurrentPath().getAddress());
         }
 
         if (!filePresent(path)) {
             throw new CommandException(
                     String.format(MESSAGE_FILE_NOT_FOUND, path));
         }
-        model.addTag(tag);
+
+        Tag absPathTag = toTag.toAbsolute(isAbsolutePath, model.getCurrentPath().getAddress());
+
+        model.addTag(absPathTag);
 
         // Save commit for undo
         model.commitAddressBook();
 
-        return new CommandResult(String.format(MESSAGE_SUCCESS, toTag));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, absPathTag));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -160,7 +160,7 @@ public class ModelManager implements Model {
     public List<Tag> findFilteredTagList(Predicate<Tag> predicate) {
         requireNonNull(predicate);
 
-        return getFilteredTagList().stream()
+        return filteredTags.getSource().stream()
                 .filter(predicate)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -3,6 +3,7 @@ package seedu.address.model.tag;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashSet;
@@ -65,7 +66,14 @@ public class Tag {
         if (!file.exists()) {
             throw new IllegalArgumentException("Tag address not valid!");
         }
-        FileAddress absAddress = new FileAddress(Paths.get(file.getAbsolutePath()).normalize().toString());
+
+        FileAddress absAddress;
+
+        try {
+            absAddress = new FileAddress(Paths.get(file.getCanonicalPath()).normalize().toString());
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Tag address not found!");
+        }
 
         return new Tag(tagName, absAddress, labels);
     }

--- a/src/test/java/seedu/address/logic/commands/ModelStubAcceptingTagAdded.java
+++ b/src/test/java/seedu/address/logic/commands/ModelStubAcceptingTagAdded.java
@@ -6,6 +6,8 @@ import java.util.ArrayList;
 
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.explorer.CurrentPath;
+import seedu.address.model.explorer.FileList;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -24,6 +26,11 @@ class ModelStubAcceptingTagAdded extends ModelStub {
     public void addTag(Tag tag) {
         requireNonNull(tag);
         tagsAdded.add(tag);
+    }
+
+    @Override
+    public CurrentPath getCurrentPath() {
+        return new CurrentPath(System.getProperty("user.dir"), new FileList());
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/TagCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/TagCommandIntegrationTest.java
@@ -20,10 +20,10 @@ public class TagCommandIntegrationTest {
     @Test
     public void execute_newTag_success() {
         Model model = new ModelStubWithTagAndTaglist();
-        Tag validTag = new TagBuilder().build();
+        Tag validTag = new TagBuilder().build().toAbsolute(false, new FileAddress(USER_DIRECTORY_ADDRESS));
 
         Model expectedModel = new ModelStubWithTagAndTaglist();
-        expectedModel.addTag(validTag.toAbsolute(false, new FileAddress(USER_DIRECTORY_ADDRESS)));
+        expectedModel.addTag(validTag);
         expectedModel.commitAddressBook();
 
         assertCommandSuccess(new TagCommand(validTag), model,


### PR DESCRIPTION
Fix show/openCommand can't open a tag that is not currently in the tagList. Resolve #199 

Fix tag not showing the correct letter case when using lower case to tag upper case file and vice versa. Resolve #200

Fix tagCommand not catching the exception thrown when using relative file path that is invalid. Resolve #205 
