### PR TITLE
Fix typo in code

### DIFF
--- a/src/main/java/seedu/address/logic/commands/OpenCommand.java
+++ b/src/main/java/seedu/address/logic/commands/OpenCommand.java
@@ -137,7 +137,7 @@ public class OpenCommand extends Command {
                     } catch (IOException e) {
                         e.printStackTrace();
                     }
-                });
+                }).start();
                 result.put(tag, String.format(MESSAGE_SUCCESS, tag));
             }
         });


### PR DESCRIPTION
Fix a typo in code when copying from my linux distro by hand. Forgot to start the thread. I'm sad.😢

Proof that it works:
![image](https://user-images.githubusercontent.com/51979232/97608671-9b957780-1a4d-11eb-9726-f482c0fdf1c2.png)
